### PR TITLE
Mask support

### DIFF
--- a/lib/puppet/provider/systemctl/systemctl.rb
+++ b/lib/puppet/provider/systemctl/systemctl.rb
@@ -17,14 +17,15 @@ Puppet::Type.type(:systemctl).provide(:systemctl) do
   end
 
   def create
-    case resource[:command]
-    when 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart'
-      comm = resource[:command] 
-    else
-      raise Puppet::Error, "Command must be one of: 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart'"
-    end
+   # case resource[:command]
+   # when 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask'
+   #   comm = resource[:command]
+   # else
+   #   raise Puppet::Error, "Command must be one of: 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask'"
+   # end
     begin
-      systemctl(comm, "#{name}.service")
+      comm = resource[:command]
+      systemctl(comm, "#{name}")
     rescue Puppet::ExecutionFailure => e
       raise Puppet::Error, "Command failed with: #{e}"
     end
@@ -42,14 +43,14 @@ Puppet::Type.type(:systemctl).provide(:systemctl) do
         return status
       end
       return !status
-    when 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart'
+    when 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask'
       return false
     end
   end
 
   def self.isenabled?
     begin
-      systemctl('is-enabled', "#{name}.service")
+      systemctl('is-enabled', "#{name}")
       return true
     rescue Puppet::ExecutionFailure => e
       return false
@@ -58,7 +59,7 @@ Puppet::Type.type(:systemctl).provide(:systemctl) do
   
   def self.status?
     begin
-      systemctl('status', "#{name}.service")
+      systemctl('status', "#{name}")
       return true
     rescue Puppet::ExecutionFailure => e
       return false

--- a/lib/puppet/type/systemctl.rb
+++ b/lib/puppet/type/systemctl.rb
@@ -10,12 +10,11 @@ Puppet::Type.newtype(:systemctl) do
 
   newparam(:name, :namevar => :true) do
      desc "The name of the service to configure."
-     newvalues(/^([a-z0-9-]+)$/i)
   end 
 
   newproperty(:command) do
-    desc "Command to pass to systemctl. One of 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart'"
-    newvalues('enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart')
+    desc "Command to pass to systemctl. One of 'enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask'"
+    newvalues('enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask')
   end
 
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "aimonb-systemd",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "aimonb",
   "summary": "Puppet interface to systemctl",
   "license": "Apache License",

--- a/spec/fixtures/modules/stdlib
+++ b/spec/fixtures/modules/stdlib
@@ -1,0 +1,1 @@
+/home/nfs/balgroupit.com/b035135/git/systemd/../stdlib

--- a/spec/fixtures/modules/stdlib
+++ b/spec/fixtures/modules/stdlib
@@ -1,1 +1,0 @@
-/home/nfs/balgroupit.com/b035135/git/systemd/../stdlib

--- a/spec/fixtures/modules/systemd
+++ b/spec/fixtures/modules/systemd
@@ -1,0 +1,1 @@
+/home/nfs/balgroupit.com/b035135/git/systemd

--- a/spec/fixtures/modules/systemd
+++ b/spec/fixtures/modules/systemd
@@ -1,1 +1,0 @@
-/home/nfs/balgroupit.com/b035135/git/systemd

--- a/spec/type/systemctl_spec.rb
+++ b/spec/type/systemctl_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Type.type(:systemctl) do
       end
     end
     
-    ['enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart'].each do |command|
+    ['enable', 'disable', 'start', 'stop', 'restart', 'try-restart', 'reload', 'reload-or-restart', 'reload-or-try-restart', 'mask', 'unmask'].each do |command|
       it "#{command} should work" do
         c = described_class.new(:name => 'myservice',
                                 :command => command)


### PR DESCRIPTION
Hey NexusIS,

As I removed ".service" extension ( and regex - I removed that as well cos I had to get rid of that to be able to support also some target like ctrl-alt-del.target. But you can add it again in a conclusive way. As I am not Ruby developer, I didn't.) from your code snippet, it does not matter, cos bash completes them automatically when you write just service name. With this extension the module will be capable of running on different units if full name is given.

For "case resource[:command]" block I tried a few things that I found out but could not get it work without commenting that block.

Best,
Cem
